### PR TITLE
Added NodeOverload attribute handling

### DIFF
--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -149,6 +149,7 @@ using {_currentNameSpace};
 
 namespace {BindingPrefix}{_currentNameSpace};
 
+{_nodeOverloadAttribute}
 {_genericTypesAttribute}
 {_oldTypeNameAttribute}
 [Category(new string[] {{""ProtoFlux/Runtimes/Execution/Nodes/{_category}""}})]
@@ -194,6 +195,7 @@ public partial class {_fullName} : global::{_baseTypeNamespace}{_baseType} {_con
         private string _constraints = "";
         private string _genericTypesAttribute;
         private string _oldTypeNameAttribute;
+        private string _nodeOverloadAttribute;
 
         private bool TypedFieldDetection(string type, string name, string targetTypeName, string declarationFormat, OrderedCount counter)
         {
@@ -343,6 +345,13 @@ public partial class {_fullName} : global::{_baseTypeNamespace}{_baseType} {_con
             if (findName?.ArgumentList != null)
                 _nodeNameOverride =
                     $"    public override string NodeName => {findName.ArgumentList.Arguments.First().ToString()};";
+            
+            var findOverload = node.AttributeLists.SelectMany(i => i.Attributes)
+                .FirstOrDefault(i => i.Name.ToString() == "NodeOverload");
+
+            
+            if (findOverload?.ArgumentList != null)
+                _nodeOverloadAttribute = $"[Grouping({findOverload.ArgumentList.Arguments.First().ToString()})]";
             
             foreach (var u in _usingDeclarations)
             {


### PR DESCRIPTION
Added NodeOverload attribute parsing to the generator to group similar ProtoFlux nodes together.

It takes the NodeOverload attribute, if it exists, and takes its contents to add a Grouping attribute in the bindings. This is the same behaviour as the official bindings generator when i checked some of my older nodes with bindings made from the official generator.

Fixes issue #6