### PR TITLE
Overhaul, support abstract base classes for nodes, remove hardcoded valid node types

### DIFF
--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -112,8 +112,7 @@ namespace SourceGenerators
             "AsyncActionFlowNode", 
             "AsyncActionBreakableFlowNode",
 
-            "ProxyVoidNode",
-            "AudioNodeBase"
+            "ProxyVoidNode"
         };
 
         private string UsingEnumerate =>
@@ -329,15 +328,15 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
             var baseTypeName = firstBaseType.Type.ToString();
             
             _baseType = baseTypeName;
-            if (baseTypeName.Contains("Proxy"))
-            {
-                _baseTypeNamespace = "FrooxEngine.FrooxEngine.ProtoFlux.";
-            }
+            //if (baseTypeName.Contains("Proxy"))
+            //{
+            //    _baseTypeNamespace = "FrooxEngine.FrooxEngine.ProtoFlux.";
+            //}
 
-            if (baseTypeName.Contains("AudioNodeBase"))
-            {
-                _baseTypeNamespace = "FrooxEngine.ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio.";
-            }
+            //if (baseTypeName.Contains("AudioNodeBase"))
+            //{
+            //    _baseTypeNamespace = "FrooxEngine.ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio.";
+            //}
 
             if (node.AttributeLists.Any()) // if has any attributes
             {
@@ -372,23 +371,25 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
                     _nodeOverloadAttribute = $"[Grouping({findOverload.ArgumentList.Arguments.First().ToString()})]";
             }
 
-            foreach (var u in _usingDeclarations)
-            {
-                var fullNameSpace = "";
-                if (string.IsNullOrEmpty(u))
-                    fullNameSpace = baseTypeName;
-                else
-                    fullNameSpace = u + "." + baseTypeName;
+            //foreach (var u in _usingDeclarations)
+            //{
+            //    var fullNameSpace = "";
+            //    if (string.IsNullOrEmpty(u))
+            //        fullNameSpace = baseTypeName;
+            //    else
+            //        fullNameSpace = u + "." + baseTypeName;
 
-                var match = ValidNodeTypes.FirstOrDefault(i => fullNameSpace.StartsWith(FluxPrefix + i));
+            //    var match = ValidNodeTypes.FirstOrDefault(i => fullNameSpace.StartsWith(FluxPrefix + i));
 
-                if (match is null) continue;
+            //    if (match is null) continue;
 
-                _match = match;
-                _fullBaseType = fullNameSpace;
-                _valid = true;
-                break;
-            }
+            //    _match = match;
+            //    _fullBaseType = fullNameSpace;
+            //    _valid = true;
+            //    break;
+            //}
+
+            _valid = true;
 
             base.VisitClassDeclaration(node);
         }

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -200,9 +200,6 @@ public {(_isAbstract ? "abstract" : "")} class {_fullName} : {_baseType} {_const
         private string _additionalName = "";
         public string BaseName;
         private string _baseType;
-        //private string _baseTypeNamespace = "FrooxEngine.ProtoFlux.Runtimes.Execution.";
-        private string _fullBaseType;
-        private string _match;
         private string _category;
         private string _nodeNameOverride = "";
         private string _debug = "";
@@ -301,11 +298,6 @@ public {(_isAbstract ? "abstract" : "")} class {_fullName} : {_baseType} {_const
                 var usingName = node.Name.ToString();
                 if (usingName == "FrooxEngine.ProtoFlux")
                     usingName = "FrooxEngine.FrooxEngine.ProtoFlux";
-                //if (usingName == "ProtoFlux.Core")
-                //{
-                //    _usingDeclarations.Add("FrooxEngine.ProtoFlux.Runtimes.Execution");
-                //    _usingDeclarations.Add("FrooxEngine.ProtoFlux");
-                //}\
                 if (usingName == "ProtoFlux.Runtimes.Execution")
                     usingName = "FrooxEngine." + usingName;
                     
@@ -320,19 +312,6 @@ public {(_isAbstract ? "abstract" : "")} class {_fullName} : {_baseType} {_const
                 base.VisitClassDeclaration(node);
                 return;
             }
-
-            //if (BaseTypes is null)
-            //{
-            //    BaseTypes = new();
-            //    if (node.BaseList is not null)
-            //    {
-            //        foreach (var baseType in node.BaseList?.Types)
-            //        {
-            //            BaseTypes.Add(baseType.ToString());
-            //        }
-            //    }
-            //    File.WriteAllText($"C:\\ObsidianBindingsDebug\\{node.Identifier.Text}_BaseTypes.txt", string.Join(",", BaseTypes));
-            //}
 
             if (node.Modifiers.Any(m => m.ToString() == "abstract"))
             {
@@ -366,16 +345,6 @@ public {(_isAbstract ? "abstract" : "")} class {_fullName} : {_baseType} {_const
             
             _baseType = baseTypeName;
 
-            //if (baseTypeName.Contains("Proxy"))
-            //{
-            //    _baseTypeNamespace = "FrooxEngine.FrooxEngine.ProtoFlux.";
-            //}
-
-            //if (baseTypeName.Contains("AudioNodeBase"))
-            //{
-            //    _baseTypeNamespace = "FrooxEngine.ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio.";
-            //}
-
             if (node.AttributeLists.Any()) // if has any attributes
             {
                 // category
@@ -385,7 +354,7 @@ public {(_isAbstract ? "abstract" : "")} class {_fullName} : {_baseType} {_const
                 if (nodeCategoryAttr?.ArgumentList is not null)
                 {
                     _category = nodeCategoryAttr.ArgumentList.Arguments.First().ToString().TrimEnds(1, 1);
-                    _valid = true;
+                    _valid = true; // If it has the NodeCategory attribute it MUST be a node
                 }
 
                 // generic types
@@ -399,34 +368,23 @@ public {(_isAbstract ? "abstract" : "")} class {_fullName} : {_baseType} {_const
                     .FirstOrDefault(i => i.Name.ToString() == "NodeName");
 
                 if (findName?.ArgumentList != null)
+                {
                     _nodeNameOverride =
                         $"    public override string NodeName => {findName.ArgumentList.Arguments.First().ToString()};";
+                    _valid = true;
+                }
+                    
 
                 // overload
                 var findOverload = node.AttributeLists.SelectMany(i => i.Attributes)
                     .FirstOrDefault(i => i.Name.ToString() == "NodeOverload");
 
                 if (findOverload?.ArgumentList != null)
+                {
                     _nodeOverloadAttribute = $"[Grouping({findOverload.ArgumentList.Arguments.First().ToString()})]";
+                    _valid = true;
+                }
             }
-
-            //foreach (var u in _usingDeclarations)
-            //{
-            //    var fullNameSpace = "";
-            //    if (string.IsNullOrEmpty(u))
-            //        fullNameSpace = baseTypeName;
-            //    else
-            //        fullNameSpace = u + "." + baseTypeName;
-
-            //    var match = ValidNodeTypes.FirstOrDefault(i => fullNameSpace.StartsWith(FluxPrefix + i));
-
-            //    if (match is null) continue;
-
-            //    _match = match;
-            //    _fullBaseType = fullNameSpace;
-            //    _valid = true;
-            //    break;
-            //}
 
             base.VisitClassDeclaration(node);
         }

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -333,6 +333,10 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
             {
                 _baseTypeNamespace = "FrooxEngine.FrooxEngine.ProtoFlux.";
             }
+            else if (baseTypeName.Contains("AudioNodeBase"))
+            {
+                _baseTypeNamespace = "ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio.";
+            }
 
             //if (baseTypeName.Contains("AudioNodeBase"))
             //{

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -182,7 +182,7 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
 """ : "")}
 {($"""
     protected override void AssociateInstanceInternal(INode node) => this.TypedNodeInstance = node is global::{_currentNameSpace}.{_fullName} localVar ? localVar : throw new System.ArgumentException("Node instance is not of type " + typeof (global::{_currentNameSpace}.{_fullName})?.ToString());
-""")};
+""")}
 {GetOverride}
 }}";
                 return str;

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -190,7 +190,8 @@ public {(_isAbstract ? "abstract" : "")} class {_fullName} : {_baseType} {_const
         private readonly List<string> _usingDeclarations = ["FrooxEngineContext = FrooxEngine.ProtoFlux.FrooxEngineContext",
             "INodeOutput = FrooxEngine.ProtoFlux.INodeOutput",
             "INodeOperation = FrooxEngine.ProtoFlux.INodeOperation",
-            "ExecutionContext = ProtoFlux.Runtimes.Execution.ExecutionContext"];
+            "ExecutionContext = ProtoFlux.Runtimes.Execution.ExecutionContext",
+            "FrooxEngine"];
         private bool _valid;
         private string _currentNameSpace;
         private string _fullName;

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -298,12 +298,7 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
                 return;
             }
 
-            if (node.BaseList.Types.Any(t => t.Type.ToString().Contains("ProtoFlux.Runtimes.Execution.ExecutionNode")))
-            {
-                _valid = true;
-            }
-
-            if (node.Modifiers.Any(m => m.ToString() == "abstract") && _currentNameSpace.ToLower().Contains("obsidian"))
+            if (node.Modifiers.Any(m => m.ToString() == "abstract"))// && _currentNameSpace.ToLower().Contains("obsidian"))
             {
                 _isAbstract = true;
             }
@@ -344,11 +339,6 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
                 _baseTypeNamespace = "FrooxEngine.ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio.";
             }
 
-            //if (baseTypeName.Contains("AudioNodeBase"))
-            //{
-            //    _baseTypeNamespace = "ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio.";
-            //}
-
             if (node.AttributeLists.Any()) // if has any attributes
             {
                 // category
@@ -382,25 +372,23 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
                     _nodeOverloadAttribute = $"[Grouping({findOverload.ArgumentList.Arguments.First().ToString()})]";
             }
 
-            //foreach (var u in _usingDeclarations)
-            //{
-            //    var fullNameSpace = "";
-            //    if (string.IsNullOrEmpty(u))
-            //        fullNameSpace = baseTypeName;
-            //    else
-            //        fullNameSpace = u + "." + baseTypeName;
+            foreach (var u in _usingDeclarations)
+            {
+                var fullNameSpace = "";
+                if (string.IsNullOrEmpty(u))
+                    fullNameSpace = baseTypeName;
+                else
+                    fullNameSpace = u + "." + baseTypeName;
 
-            //    var match = ValidNodeTypes.FirstOrDefault(i => fullNameSpace.StartsWith(FluxPrefix + i));
+                var match = ValidNodeTypes.FirstOrDefault(i => fullNameSpace.StartsWith(FluxPrefix + i));
 
-            //    if (match is null) continue;
+                if (match is null) continue;
 
-            //    _match = match;
-            //    _fullBaseType = fullNameSpace;
-            //    _valid = true;
-            //    break;
-            //}
-
-            //_valid = true;
+                _match = match;
+                _fullBaseType = fullNameSpace;
+                _valid = true;
+                break;
+            }
 
             base.VisitClassDeclaration(node);
         }

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -292,8 +292,8 @@ public {(_isAbstract ? "abstract" : "")} class {_fullName} : {_baseType} {_const
                 var usingName = node.Name.ToString();
                 if (usingName == "FrooxEngine.ProtoFlux")
                     usingName = "FrooxEngine.FrooxEngine.ProtoFlux";
-                else if (usingName == "ProtoFlux.Core")
-                    usingName = "FrooxEngine.ProtoFlux.Runtimes.Execution";
+                if (usingName == "ProtoFlux.Core")
+                    _usingDeclarations.Add("FrooxEngine.ProtoFlux.Runtimes.Execution");
                 _usingDeclarations.Add(usingName);
             }
             base.VisitUsingDirective(node);

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -92,8 +92,8 @@ namespace SourceGenerators
             }
         }
         
-        public const string BindingPrefix = "Bindings.";
-        public const string FluxPrefix = "ProtoFlux.Runtimes.Execution.";
+        public const string BindingPrefix = "FrooxEngine.";
+        //public const string FluxPrefix = "ProtoFlux.Runtimes.Execution.";
 
         //TODO: add more, this is not all of the valid node types
         public static readonly string[] ValidNodeTypes =

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -298,6 +298,11 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
                 return;
             }
 
+            if (node.BaseList.Types.Any(t => t.Type.ToString().Contains("ExecutionNode")))
+            {
+                _valid = true;
+            }
+
             if (node.Modifiers.Any(m => m.ToString() == "abstract") && _currentNameSpace.ToLower().Contains("obsidian"))
             {
                 _isAbstract = true;
@@ -333,6 +338,7 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
             {
                 _baseTypeNamespace = "FrooxEngine.FrooxEngine.ProtoFlux.";
             }
+
             if (baseTypeName.Contains("AudioNodeBase"))
             {
                 _baseTypeNamespace = "FrooxEngine.ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio.";
@@ -393,6 +399,8 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
             //    _valid = true;
             //    break;
             //}
+
+            _valid = true;
 
             base.VisitClassDeclaration(node);
         }

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -300,7 +300,7 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
 
             if (node.Modifiers.Any(m => m.ToString() == "abstract") && _currentNameSpace.ToLower().Contains("obsidian"))
             {
-                _isAbstract = true;
+                //_isAbstract = true;
             }
 
             var baseName = node.Identifier.Text;

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -295,7 +295,9 @@ public {(_isAbstract ? "abstract" : "")} class {_fullName} : {_baseType} {_const
                 //{
                 //    _usingDeclarations.Add("FrooxEngine.ProtoFlux.Runtimes.Execution");
                 //    _usingDeclarations.Add("FrooxEngine.ProtoFlux");
-                //}
+                //}\
+                if (usingName.StartsWith("ProtoFlux.Runtimes.Execution"))
+                    usingName = "FrooxEngine." + usingName;
                     
                 _usingDeclarations.Add(usingName);
             }

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -94,6 +94,7 @@ namespace SourceGenerators
         }
         
         public const string BindingPrefix = "Bindings.";
+        public const string LegacyBindingPrefix = "FrooxEngine.";
 
         private string UsingEnumerate =>
             _usingDeclarations
@@ -136,7 +137,7 @@ namespace {BindingPrefix}{_currentNameSpace};
 {_nodeOverloadAttribute}
 {_genericTypesAttribute}
 {_oldTypeNameAttribute}
-{(_backCompat && !_isAbstract ? $"[OldTypeName(\"{"FrooxEngine." + _currentNameSpace + "." + BaseName}\")]" : "")}
+{(!_isAbstract ? $"[OldTypeName(\"{LegacyBindingPrefix + _currentNameSpace + "." + BaseName}\")]" : "")}
 [Category(new string[] {{""ProtoFlux/Runtimes/Execution/Nodes/{_category}""}})]
 public {(_isAbstract ? "abstract" : "")} class {_fullName} : {_baseType} {_constraints}
 {{
@@ -258,16 +259,16 @@ public {(_isAbstract ? "abstract" : "")} class {_fullName} : {_baseType} {_const
         public override void VisitNamespaceDeclaration(NamespaceDeclarationSyntax node)
         {
             _currentNameSpace = node.Name.ToString();
-            if (_currentNameSpace.StartsWith("ProtoFlux.Runtimes.Execution.Nodes."))
-                _backCompat = true;
+            //if (_currentNameSpace.StartsWith("ProtoFlux.Runtimes.Execution.Nodes."))
+            //    _backCompat = true;
             base.VisitNamespaceDeclaration(node);
         }
 
         public override void VisitFileScopedNamespaceDeclaration(FileScopedNamespaceDeclarationSyntax node)
         {
             _currentNameSpace = node.Name.ToString();
-            if (_currentNameSpace.StartsWith("ProtoFlux.Runtimes.Execution.Nodes."))
-                _backCompat = true;
+            //if (_currentNameSpace.StartsWith("ProtoFlux.Runtimes.Execution.Nodes."))
+            //    _backCompat = true;
             base.VisitFileScopedNamespaceDeclaration(node);
         }
 

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -157,7 +157,7 @@ namespace {BindingPrefix}{_currentNameSpace};
 {_genericTypesAttribute}
 {_oldTypeNameAttribute}
 [Category(new string[] {{""ProtoFlux/Runtimes/Execution/Nodes/{_category}""}})]
-public partial class {_fullName} : global::{_baseTypeNamespace}{_baseType} {_constraints}
+public partial {(_isAbstract ? "abstract" : "")} class {_fullName} : global::{_baseTypeNamespace}{_baseType} {_constraints}
 {{
 {(string.IsNullOrEmpty(_debug) ? "" : "//")}{_debug}
 {Declarations}

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -298,7 +298,7 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
                 return;
             }
 
-            if (node.Modifiers.Any(m => m.ToString() == "abstract"))// && _currentNameSpace.ToLower().Contains("obsidian"))
+            if (node.Modifiers.Any(m => m.ToString() == "abstract"))
             {
                 _isAbstract = true;
             }

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -293,7 +293,11 @@ public {(_isAbstract ? "abstract" : "")} class {_fullName} : {_baseType} {_const
                 if (usingName == "FrooxEngine.ProtoFlux")
                     usingName = "FrooxEngine.FrooxEngine.ProtoFlux";
                 if (usingName == "ProtoFlux.Core")
+                {
                     _usingDeclarations.Add("FrooxEngine.ProtoFlux.Runtimes.Execution");
+                    _usingDeclarations.Add("FrooxEngine.ProtoFlux");
+                }
+                    
                 _usingDeclarations.Add(usingName);
             }
             base.VisitUsingDirective(node);

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -187,8 +187,7 @@ public {(_isAbstract ? "abstract" : "")} class {_fullName} : {_baseType} {_const
                 return str;
             }
         }
-
-        private readonly List<string> _usingDeclarations = [""];
+        private readonly List<string> _usingDeclarations = ["FrooxEngineContext = FrooxEngine.ProtoFlux.FrooxEngineContext", "INodeOutput = FrooxEngine.ProtoFlux.INodeOutput", "INodeOperation = FrooxEngine.ProtoFlux.INodeOperation"];
         private bool _valid;
         private string _currentNameSpace;
         private string _fullName;
@@ -292,11 +291,11 @@ public {(_isAbstract ? "abstract" : "")} class {_fullName} : {_baseType} {_const
                 var usingName = node.Name.ToString();
                 if (usingName == "FrooxEngine.ProtoFlux")
                     usingName = "FrooxEngine.FrooxEngine.ProtoFlux";
-                if (usingName == "ProtoFlux.Core")
-                {
-                    _usingDeclarations.Add("FrooxEngine.ProtoFlux.Runtimes.Execution");
-                    _usingDeclarations.Add("FrooxEngine.ProtoFlux");
-                }
+                //if (usingName == "ProtoFlux.Core")
+                //{
+                //    _usingDeclarations.Add("FrooxEngine.ProtoFlux.Runtimes.Execution");
+                //    _usingDeclarations.Add("FrooxEngine.ProtoFlux");
+                //}
                     
                 _usingDeclarations.Add(usingName);
             }

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -376,23 +376,23 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
                     _nodeOverloadAttribute = $"[Grouping({findOverload.ArgumentList.Arguments.First().ToString()})]";
             }
 
-            foreach (var u in _usingDeclarations)
-            {
-                var fullNameSpace = "";
-                if (string.IsNullOrEmpty(u))
-                    fullNameSpace = baseTypeName;
-                else
-                    fullNameSpace = u + "." + baseTypeName;
+            //foreach (var u in _usingDeclarations)
+            //{
+            //    var fullNameSpace = "";
+            //    if (string.IsNullOrEmpty(u))
+            //        fullNameSpace = baseTypeName;
+            //    else
+            //        fullNameSpace = u + "." + baseTypeName;
 
-                var match = ValidNodeTypes.FirstOrDefault(i => fullNameSpace.StartsWith(FluxPrefix + i));
+            //    var match = ValidNodeTypes.FirstOrDefault(i => fullNameSpace.StartsWith(FluxPrefix + i));
 
-                if (match is null) continue;
+            //    if (match is null) continue;
 
-                _match = match;
-                _fullBaseType = fullNameSpace;
-                _valid = true;
-                break;
-            }
+            //    _match = match;
+            //    _fullBaseType = fullNameSpace;
+            //    _valid = true;
+            //    break;
+            //}
 
             base.VisitClassDeclaration(node);
         }

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -298,18 +298,18 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
                 return;
             }
 
-            if (BaseTypes is null)
-            {
-                BaseTypes = new();
-                if (node.BaseList is not null)
-                {
-                    foreach (var baseType in node.BaseList?.Types)
-                    {
-                        BaseTypes.Add(baseType.ToString());
-                    }
-                }
-                File.WriteAllText($"C:\\ObsidianBindingsDebug\\{node.Identifier.Text}_BaseTypes.txt", string.Join(",", BaseTypes));
-            }
+            //if (BaseTypes is null)
+            //{
+            //    BaseTypes = new();
+            //    if (node.BaseList is not null)
+            //    {
+            //        foreach (var baseType in node.BaseList?.Types)
+            //        {
+            //            BaseTypes.Add(baseType.ToString());
+            //        }
+            //    }
+            //    File.WriteAllText($"C:\\ObsidianBindingsDebug\\{node.Identifier.Text}_BaseTypes.txt", string.Join(",", BaseTypes));
+            //}
 
             if (node.Modifiers.Any(m => m.ToString() == "abstract"))
             {
@@ -361,6 +361,7 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
                 if (nodeCategoryAttr?.ArgumentList is not null)
                 {
                     _category = nodeCategoryAttr.ArgumentList.Arguments.First().ToString().TrimEnds(1, 1);
+                    _valid = true;
                 }
 
                 // generic types
@@ -402,8 +403,6 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
             //    _valid = true;
             //    break;
             //}
-
-            _valid = true;
 
             base.VisitClassDeclaration(node);
         }

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -195,7 +195,7 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : {_baseType}
         private string _additionalName = "";
         public string BaseName;
         private string _baseType;
-        private string _baseTypeNamespace = "FrooxEngine.ProtoFlux.Runtimes.Execution.";
+        //private string _baseTypeNamespace = "FrooxEngine.ProtoFlux.Runtimes.Execution.";
         private string _fullBaseType;
         private string _match;
         private string _category;
@@ -287,7 +287,15 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : {_baseType}
 
         public override void VisitUsingDirective(UsingDirectiveSyntax node)
         {
-            if (node.Name is not null) _usingDeclarations.Add(node.Name.ToString());
+            if (node.Name is not null)
+            {
+                var usingName = node.Name.ToString();
+                if (usingName == "FrooxEngine.ProtoFlux")
+                    usingName = "FrooxEngine.FrooxEngine.ProtoFlux";
+                else if (usingName == "ProtoFlux.Core")
+                    usingName = "FrooxEngine.ProtoFlux.Runtimes.Execution";
+                _usingDeclarations.Add(node.Name.ToString());
+            }
             base.VisitUsingDirective(node);
         }
         public override void VisitClassDeclaration(ClassDeclarationSyntax node)

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -157,7 +157,7 @@ namespace {BindingPrefix}{_currentNameSpace};
 {_genericTypesAttribute}
 {_oldTypeNameAttribute}
 [Category(new string[] {{""ProtoFlux/Runtimes/Execution/Nodes/{_category}""}})]
-public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_baseTypeNamespace}{_baseType} {_constraints}
+public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : {_baseType} {_constraints}
 {{
 {(string.IsNullOrEmpty(_debug) ? "" : "//")}{_debug}
 {Declarations}
@@ -342,6 +342,7 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
             var baseTypeName = firstBaseType.Type.ToString();
             
             _baseType = baseTypeName;
+
             //if (baseTypeName.Contains("Proxy"))
             //{
             //    _baseTypeNamespace = "FrooxEngine.FrooxEngine.ProtoFlux.";

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -165,9 +165,9 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
 {_nodeNameOverride}
 {(_isValidGenericTypeMethod ? $"    public static bool IsValidGenericType => global::{_currentNameSpace}.{_fullName}.IsValidGenericType;" : "")}
     public override System.Type NodeType => typeof (global::{_currentNameSpace}.{_fullName});
-{(!_isAbstract ? $"    public global::{_currentNameSpace}.{_fullName}" + " TypedNodeInstance { get; private set; }" : "")}
-{(!_isAbstract ? "    public override INode NodeInstance => (INode)this.TypedNodeInstance;" : "")}
-{(!_isAbstract ? "    public override void ClearInstance() => this.TypedNodeInstance = null;" : "")}
+{($"    public global::{_currentNameSpace}.{_fullName}" + " TypedNodeInstance { get; private set; }")}
+    public override INode NodeInstance => (INode)this.TypedNodeInstance;
+    public override void ClearInstance() => this.TypedNodeInstance = null;
 {CountOverride}
 {(!_isAbstract ? """
     public override N Instantiate<N>()
@@ -300,7 +300,7 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
 
             if (node.Modifiers.Any(m => m.ToString() == "abstract") && _currentNameSpace.ToLower().Contains("obsidian"))
             {
-                //_isAbstract = true;
+                _isAbstract = true;
             }
 
             var baseName = node.Identifier.Text;

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -112,7 +112,8 @@ namespace SourceGenerators
             "AsyncActionFlowNode", 
             "AsyncActionBreakableFlowNode",
 
-            "ProxyVoidNode"
+            "ProxyVoidNode",
+            "AudioNodeBase"
         };
 
         private string UsingEnumerate =>
@@ -371,25 +372,23 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
                     _nodeOverloadAttribute = $"[Grouping({findOverload.ArgumentList.Arguments.First().ToString()})]";
             }
 
-            //foreach (var u in _usingDeclarations)
-            //{
-            //    var fullNameSpace = "";
-            //    if (string.IsNullOrEmpty(u))
-            //        fullNameSpace = baseTypeName;
-            //    else
-            //        fullNameSpace = u + "." + baseTypeName;
+            foreach (var u in _usingDeclarations)
+            {
+                var fullNameSpace = "";
+                if (string.IsNullOrEmpty(u))
+                    fullNameSpace = baseTypeName;
+                else
+                    fullNameSpace = u + "." + baseTypeName;
 
-            //    var match = ValidNodeTypes.FirstOrDefault(i => fullNameSpace.StartsWith(FluxPrefix + i));
+                var match = ValidNodeTypes.FirstOrDefault(i => fullNameSpace.StartsWith(FluxPrefix + i));
 
-            //    if (match is null) continue;
-                
-            //    _match = match;
-            //    _fullBaseType = fullNameSpace;
-            //    _valid = true;
-            //    break;
-            //}
+                if (match is null) continue;
 
-            _valid = true;
+                _match = match;
+                _fullBaseType = fullNameSpace;
+                _valid = true;
+                break;
+            }
 
             base.VisitClassDeclaration(node);
         }

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -187,7 +187,10 @@ public {(_isAbstract ? "abstract" : "")} class {_fullName} : {_baseType} {_const
                 return str;
             }
         }
-        private readonly List<string> _usingDeclarations = ["FrooxEngineContext = FrooxEngine.ProtoFlux.FrooxEngineContext", "INodeOutput = FrooxEngine.ProtoFlux.INodeOutput", "INodeOperation = FrooxEngine.ProtoFlux.INodeOperation"];
+        private readonly List<string> _usingDeclarations = ["FrooxEngineContext = FrooxEngine.ProtoFlux.FrooxEngineContext",
+            "INodeOutput = FrooxEngine.ProtoFlux.INodeOutput",
+            "INodeOperation = FrooxEngine.ProtoFlux.INodeOperation",
+            "ExecutionContext = ProtoFlux.Runtimes.Execution.ExecutionContext"];
         private bool _valid;
         private string _currentNameSpace;
         private string _fullName;

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -95,27 +95,6 @@ namespace SourceGenerators
         }
         
         public const string BindingPrefix = "Bindings.";
-        //public const string FluxPrefix = "ProtoFlux.Runtimes.Execution.";
-
-        //TODO: add more, this is not all of the valid node types
-        public static readonly string[] ValidNodeTypes =
-        {
-            "NestedNode",
-            "VoidNode", 
-            
-            "ObjectFunctionNode", 
-            "ValueFunctionNode", 
-
-            "ActionNode", 
-            "ActionFlowNode",
-            "ActionBreakableFlowNode",
-            
-            "AsyncActionNode", 
-            "AsyncActionFlowNode", 
-            "AsyncActionBreakableFlowNode",
-
-            "ProxyVoidNode"
-        };
 
         private string UsingEnumerate =>
             _usingDeclarations

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -112,7 +112,8 @@ namespace SourceGenerators
             "AsyncActionFlowNode", 
             "AsyncActionBreakableFlowNode",
 
-            "ProxyVoidNode"
+            "ProxyVoidNode",
+            "AudioNodeBase"
         };
 
         private string UsingEnumerate =>

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -174,7 +174,6 @@ public partial class {_fullName} : global::{_baseTypeNamespace}{_baseType} {_con
     }
     protected override void AssociateInstanceInternal(INode node) => this.TypedNodeInstance = node is global::{_currentNameSpace}.{_fullName} localVar ? localVar : throw new System.ArgumentException("Node instance is not of type " + typeof (global::{_currentNameSpace}.{_fullName})?.ToString());
 """ : "")}
-
 {GetOverride}
 }}";
                 return str;
@@ -290,7 +289,7 @@ public partial class {_fullName} : global::{_baseTypeNamespace}{_baseType} {_con
                 return;
             }
 
-            if (node.Modifiers.Any(m => m.ToString() == "abstract"))
+            if (node.Modifiers.Any(m => m.ToString() == "abstract") && _currentNameSpace.ToLower().Contains("obsidian"))
             {
                 _isAbstract = true;
             }

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -156,7 +156,7 @@ namespace {BindingPrefix}{_currentNameSpace};
 {_nodeOverloadAttribute}
 {_genericTypesAttribute}
 {_oldTypeNameAttribute}
-{(_backCompat ? $"[OldTypeName({"FrooxEngine." + _currentNameSpace})]" : "")}
+{(_backCompat ? $"[OldTypeName(\"{"FrooxEngine." + _currentNameSpace}\")]" : "")}
 [Category(new string[] {{""ProtoFlux/Runtimes/Execution/Nodes/{_category}""}})]
 public {(_isAbstract ? "abstract" : "")} class {_fullName} : {_baseType} {_constraints}
 {{

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -179,9 +179,10 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
         return localVar as N;
 """ + """
     }
-""" + $"""
-    protected override void AssociateInstanceInternal(INode node) => this.TypedNodeInstance = node is global::{_currentNameSpace}.{_fullName} localVar ? localVar : throw new System.ArgumentException("Node instance is not of type " + typeof (global::{_currentNameSpace}.{_fullName})?.ToString());
 """ : "")}
+{($"""
+    protected override void AssociateInstanceInternal(INode node) => this.TypedNodeInstance = node is global::{_currentNameSpace}.{_fullName} localVar ? localVar : throw new System.ArgumentException("Node instance is not of type " + typeof (global::{_currentNameSpace}.{_fullName})?.ToString());
+""")};
 {GetOverride}
 }}";
                 return str;
@@ -332,6 +333,7 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
             {
                 _baseTypeNamespace = "FrooxEngine.FrooxEngine.ProtoFlux.";
             }
+
             if (baseTypeName.Contains("AudioNodeBase"))
             {
                 _baseTypeNamespace = "ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio.";

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -160,18 +160,21 @@ public partial class {_fullName} : global::{_baseTypeNamespace}{_baseType} {_con
 {_nodeNameOverride}
 {(_isValidGenericTypeMethod ? $"    public static bool IsValidGenericType => global::{_currentNameSpace}.{_fullName}.IsValidGenericType;" : "")}
     public override System.Type NodeType => typeof (global::{_currentNameSpace}.{_fullName});
-    public global::{_currentNameSpace}.{_fullName} TypedNodeInstance {{ get; private set; }}
-    public override INode NodeInstance => (INode)this.TypedNodeInstance;
-    public override void ClearInstance() => this.TypedNodeInstance = null;
+{(!_isAbstract ? "    public global::{_currentNameSpace}.{_fullName} TypedNodeInstance { get; private set; }" : "")}
+{(!_isAbstract ? "    public override INode NodeInstance => (INode)this.TypedNodeInstance;" : "")}
+{(!_isAbstract ? "    public override void ClearInstance() => this.TypedNodeInstance = null;" : "")}
 {CountOverride}
+{(!_isAbstract ? """
     public override N Instantiate<N>()
-    {{
-        if (this.TypedNodeInstance != null) throw new System.InvalidOperationException(""Node has already been instantiated"");
+    {
+        if (this.TypedNodeInstance != null) throw new System.InvalidOperationException("Node has already been instantiated");
         var localVar = new global::{_currentNameSpace}.{_fullName}();
         this.TypedNodeInstance = localVar;
         return localVar as N;
-    }}
-    protected override void AssociateInstanceInternal(INode node) => this.TypedNodeInstance = node is global::{_currentNameSpace}.{_fullName} localVar ? localVar : throw new System.ArgumentException(""Node instance is not of type "" + typeof (global::{_currentNameSpace}.{_fullName})?.ToString());
+    }
+    protected override void AssociateInstanceInternal(INode node) => this.TypedNodeInstance = node is global::{_currentNameSpace}.{_fullName} localVar ? localVar : throw new System.ArgumentException("Node instance is not of type " + typeof (global::{_currentNameSpace}.{_fullName})?.ToString());
+""" : "")}
+
 {GetOverride}
 }}";
                 return str;
@@ -196,6 +199,7 @@ public partial class {_fullName} : global::{_baseTypeNamespace}{_baseType} {_con
         private string _genericTypesAttribute;
         private string _oldTypeNameAttribute;
         private string _nodeOverloadAttribute;
+        private bool _isAbstract;
 
         private bool TypedFieldDetection(string type, string name, string targetTypeName, string declarationFormat, OrderedCount counter)
         {
@@ -288,8 +292,7 @@ public partial class {_fullName} : global::{_baseTypeNamespace}{_baseType} {_con
 
             if (node.Modifiers.Any(m => m.ToString() == "abstract"))
             {
-                base.VisitClassDeclaration(node);
-                return;
+                _isAbstract = true;
             }
 
             var baseName = node.Identifier.Text;

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -332,6 +332,10 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
             {
                 _baseTypeNamespace = "FrooxEngine.FrooxEngine.ProtoFlux.";
             }
+            if (baseTypeName.Contains("AudioNodeBase"))
+            {
+                _baseTypeNamespace = "ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio";
+            }
 
             if (node.AttributeLists.Any()) // if has any attributes
             {

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
@@ -32,7 +33,10 @@ namespace SourceGenerators
                 var res = result.ToString();
 
                 if (!string.IsNullOrWhiteSpace(res))
+                {
                     context.AddSource($"{walker.BaseName}Bindings.g.cs", result.ToString());
+                    File.WriteAllText($"C:\\ObsidianBindingsDebug\\{walker.BaseName}Bindings.g.cs", res);
+                }
             }
         }
     }

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -137,7 +137,7 @@ namespace {BindingPrefix}{_currentNameSpace};
 {_genericTypesAttribute}
 {_oldTypeNameAttribute}
 {(_backCompat ? $"[OldTypeName(\"{"FrooxEngine." + _currentNameSpace}\")]" : "")}
-[Category(new string[] {{""ProtoFlux/Runtimes/Execution/Nodes/{_category}""}})]
+[Category(new string[] {{""ProtoFlux/Runtimes/Execution/Nodes/{_category}/{BaseName}""}})]
 public {(_isAbstract ? "abstract" : "")} class {_fullName} : {_baseType} {_constraints}
 {{
 {(string.IsNullOrEmpty(_debug) ? "" : "//")}{_debug}
@@ -298,8 +298,8 @@ public {(_isAbstract ? "abstract" : "")} class {_fullName} : {_baseType} {_const
                 _isAbstract = true;
             }
 
-            var baseName = node.Identifier.Text;
-            var fullName = baseName;
+            BaseName = node.Identifier.Text;
+            var fullName = BaseName;
 
             if (node.TypeParameterList is not null)
             {
@@ -312,7 +312,6 @@ public {(_isAbstract ? "abstract" : "")} class {_fullName} : {_baseType} {_const
                 fullName += _additionalName;
             }
             
-            BaseName = baseName;
             _fullName = fullName;
 
             if (node.ConstraintClauses.Any())

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -136,7 +136,7 @@ namespace {BindingPrefix}{_currentNameSpace};
 {_nodeOverloadAttribute}
 {_genericTypesAttribute}
 {_oldTypeNameAttribute}
-{(_backCompat ? $"[OldTypeName(\"{"FrooxEngine." + _currentNameSpace + "." + BaseName}\")]" : "")}
+{(_backCompat && !_isAbstract ? $"[OldTypeName(\"{"FrooxEngine." + _currentNameSpace + "." + BaseName}\")]" : "")}
 [Category(new string[] {{""ProtoFlux/Runtimes/Execution/Nodes/{_category}""}})]
 public {(_isAbstract ? "abstract" : "")} class {_fullName} : {_baseType} {_constraints}
 {{

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -207,6 +207,7 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
         private string _oldTypeNameAttribute;
         private string _nodeOverloadAttribute;
         private bool _isAbstract;
+        private List<string> BaseTypes = null;
 
         private bool TypedFieldDetection(string type, string name, string targetTypeName, string declarationFormat, OrderedCount counter)
         {
@@ -295,6 +296,19 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
             {
                 base.VisitClassDeclaration(node);
                 return;
+            }
+
+            if (BaseTypes is null)
+            {
+                BaseTypes = new();
+                if (node.BaseList is not null)
+                {
+                    foreach (var baseType in node.BaseList?.Types)
+                    {
+                        BaseTypes.Add(baseType.ToString());
+                    }
+                }
+                File.WriteAllText($"C:\\ObsidianBindingsDebug\\{node.Identifier.Text}_BaseTypes.txt", string.Join(",", BaseTypes));
             }
 
             if (node.Modifiers.Any(m => m.ToString() == "abstract"))

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -190,7 +190,6 @@ public {(_isAbstract ? "abstract" : "")} class {_fullName} : {_baseType} {_const
         private string _oldTypeNameAttribute;
         private string _nodeOverloadAttribute;
         private bool _isAbstract;
-        private bool _backCompat;
 
         private bool TypedFieldDetection(string type, string name, string targetTypeName, string declarationFormat, OrderedCount counter)
         {
@@ -259,16 +258,12 @@ public {(_isAbstract ? "abstract" : "")} class {_fullName} : {_baseType} {_const
         public override void VisitNamespaceDeclaration(NamespaceDeclarationSyntax node)
         {
             _currentNameSpace = node.Name.ToString();
-            //if (_currentNameSpace.StartsWith("ProtoFlux.Runtimes.Execution.Nodes."))
-            //    _backCompat = true;
             base.VisitNamespaceDeclaration(node);
         }
 
         public override void VisitFileScopedNamespaceDeclaration(FileScopedNamespaceDeclarationSyntax node)
         {
             _currentNameSpace = node.Name.ToString();
-            //if (_currentNameSpace.StartsWith("ProtoFlux.Runtimes.Execution.Nodes."))
-            //    _backCompat = true;
             base.VisitFileScopedNamespaceDeclaration(node);
         }
 

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -92,7 +92,7 @@ namespace SourceGenerators
             }
         }
         
-        public const string BindingPrefix = "FrooxEngine.";
+        public const string BindingPrefix = "Bindings.";
         //public const string FluxPrefix = "ProtoFlux.Runtimes.Execution.";
 
         //TODO: add more, this is not all of the valid node types
@@ -156,6 +156,7 @@ namespace {BindingPrefix}{_currentNameSpace};
 {_nodeOverloadAttribute}
 {_genericTypesAttribute}
 {_oldTypeNameAttribute}
+{(_backCompat ? $"[OldTypeName({"FrooxEngine." + _currentNameSpace})]" : "")}
 [Category(new string[] {{""ProtoFlux/Runtimes/Execution/Nodes/{_category}""}})]
 public {(_isAbstract ? "abstract" : "")} class {_fullName} : {_baseType} {_constraints}
 {{
@@ -210,7 +211,7 @@ public {(_isAbstract ? "abstract" : "")} class {_fullName} : {_baseType} {_const
         private string _oldTypeNameAttribute;
         private string _nodeOverloadAttribute;
         private bool _isAbstract;
-        private List<string> BaseTypes = null;
+        private bool _backCompat;
 
         private bool TypedFieldDetection(string type, string name, string targetTypeName, string declarationFormat, OrderedCount counter)
         {
@@ -279,12 +280,16 @@ public {(_isAbstract ? "abstract" : "")} class {_fullName} : {_baseType} {_const
         public override void VisitNamespaceDeclaration(NamespaceDeclarationSyntax node)
         {
             _currentNameSpace = node.Name.ToString();
+            if (_currentNameSpace.StartsWith("ProtoFlux.Runtimes.Execution.Nodes."))
+                _backCompat = true;
             base.VisitNamespaceDeclaration(node);
         }
 
         public override void VisitFileScopedNamespaceDeclaration(FileScopedNamespaceDeclarationSyntax node)
         {
             _currentNameSpace = node.Name.ToString();
+            if (_currentNameSpace.StartsWith("ProtoFlux.Runtimes.Execution.Nodes."))
+                _backCompat = true;
             base.VisitFileScopedNamespaceDeclaration(node);
         }
 

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -334,7 +334,7 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
             }
             if (baseTypeName.Contains("AudioNodeBase"))
             {
-                _baseTypeNamespace = "ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio";
+                _baseTypeNamespace = "ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio.";
             }
 
             if (node.AttributeLists.Any()) // if has any attributes

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -400,7 +400,7 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
             //    break;
             //}
 
-            _valid = true;
+            //_valid = true;
 
             base.VisitClassDeclaration(node);
         }

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -298,7 +298,7 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
                 return;
             }
 
-            if (node.BaseList.Types.Any(t => t.Type.ToString().Contains("ExecutionNode")))
+            if (node.BaseList.Types.Any(t => t.Type.ToString().Contains("ProtoFlux.Runtimes.Execution.ExecutionNode")))
             {
                 _valid = true;
             }

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -157,7 +157,7 @@ namespace {BindingPrefix}{_currentNameSpace};
 {_genericTypesAttribute}
 {_oldTypeNameAttribute}
 [Category(new string[] {{""ProtoFlux/Runtimes/Execution/Nodes/{_category}""}})]
-public partial {(_isAbstract ? "abstract" : "")} class {_fullName} : global::{_baseTypeNamespace}{_baseType} {_constraints}
+public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_baseTypeNamespace}{_baseType} {_constraints}
 {{
 {(string.IsNullOrEmpty(_debug) ? "" : "//")}{_debug}
 {Declarations}

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -112,8 +112,7 @@ namespace SourceGenerators
             "AsyncActionFlowNode", 
             "AsyncActionBreakableFlowNode",
 
-            "ProxyVoidNode",
-            "AudioNodeBase"
+            "ProxyVoidNode"
         };
 
         private string UsingEnumerate =>
@@ -334,10 +333,10 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
                 _baseTypeNamespace = "FrooxEngine.FrooxEngine.ProtoFlux.";
             }
 
-            if (baseTypeName.Contains("AudioNodeBase"))
-            {
-                _baseTypeNamespace = "ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio.";
-            }
+            //if (baseTypeName.Contains("AudioNodeBase"))
+            //{
+            //    _baseTypeNamespace = "ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio.";
+            //}
 
             if (node.AttributeLists.Any()) // if has any attributes
             {
@@ -372,23 +371,25 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
                     _nodeOverloadAttribute = $"[Grouping({findOverload.ArgumentList.Arguments.First().ToString()})]";
             }
 
-            foreach (var u in _usingDeclarations)
-            {
-                var fullNameSpace = "";
-                if (string.IsNullOrEmpty(u))
-                    fullNameSpace = baseTypeName;
-                else
-                    fullNameSpace = u + "." + baseTypeName;
+            //foreach (var u in _usingDeclarations)
+            //{
+            //    var fullNameSpace = "";
+            //    if (string.IsNullOrEmpty(u))
+            //        fullNameSpace = baseTypeName;
+            //    else
+            //        fullNameSpace = u + "." + baseTypeName;
 
-                var match = ValidNodeTypes.FirstOrDefault(i => fullNameSpace.StartsWith(FluxPrefix + i));
+            //    var match = ValidNodeTypes.FirstOrDefault(i => fullNameSpace.StartsWith(FluxPrefix + i));
 
-                if (match is null) continue;
+            //    if (match is null) continue;
                 
-                _match = match;
-                _fullBaseType = fullNameSpace;
-                _valid = true;
-                break;
-            }
+            //    _match = match;
+            //    _fullBaseType = fullNameSpace;
+            //    _valid = true;
+            //    break;
+            //}
+
+            _valid = true;
 
             base.VisitClassDeclaration(node);
         }

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -294,7 +294,7 @@ public {(_isAbstract ? "abstract" : "")} class {_fullName} : {_baseType} {_const
                     usingName = "FrooxEngine.FrooxEngine.ProtoFlux";
                 else if (usingName == "ProtoFlux.Core")
                     usingName = "FrooxEngine.ProtoFlux.Runtimes.Execution";
-                _usingDeclarations.Add(node.Name.ToString());
+                _usingDeclarations.Add(usingName);
             }
             base.VisitUsingDirective(node);
         }

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -58,7 +58,7 @@ namespace SourceGenerators
             {
                 get
                 {
-                    if (VariableNames.Count == 0) return "";
+                    //if (VariableNames.Count == 0) return "";
                     var str = $@"
     protected override {MethodReturnType} {MethodName}(ref int index)
     {{

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -286,6 +286,12 @@ public partial class {_fullName} : global::{_baseTypeNamespace}{_baseType} {_con
                 return;
             }
 
+            if (node.Modifiers.Any(m => m.ToString() == "abstract"))
+            {
+                base.VisitClassDeclaration(node);
+                return;
+            }
+
             var baseName = node.Identifier.Text;
             var fullName = baseName;
 

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -329,7 +329,7 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
             var baseTypeName = firstBaseType.Type.ToString();
             
             _baseType = baseTypeName;
-            if (node.BaseList.Types.Any(t => t.Type.ToString().Contains("Proxy")))
+            if (baseTypeName.Contains("Proxy"))
             {
                 _baseTypeNamespace = "FrooxEngine.FrooxEngine.ProtoFlux.";
             }

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -157,7 +157,7 @@ namespace {BindingPrefix}{_currentNameSpace};
 {_genericTypesAttribute}
 {_oldTypeNameAttribute}
 [Category(new string[] {{""ProtoFlux/Runtimes/Execution/Nodes/{_category}""}})]
-public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : {_baseType} {_constraints}
+public {(_isAbstract ? "abstract" : "")} class {_fullName} : {_baseType} {_constraints}
 {{
 {(string.IsNullOrEmpty(_debug) ? "" : "//")}{_debug}
 {Declarations}

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -192,7 +192,8 @@ public {(_isAbstract ? "abstract" : "")} class {_fullName} : {_baseType} {_const
             "INodeOutput = FrooxEngine.ProtoFlux.INodeOutput",
             "INodeOperation = FrooxEngine.ProtoFlux.INodeOperation",
             "ExecutionContext = ProtoFlux.Runtimes.Execution.ExecutionContext",
-            "FrooxEngine"];
+            "FrooxEngine",
+            "Elements.Data"];
         private bool _valid;
         private string _currentNameSpace;
         private string _fullName;

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -16,6 +16,7 @@ namespace SourceGenerators
     [Generator]
     public class BindingGenerator : ISourceGenerator
     {
+        private const bool DEBUG = false;
         public void Initialize(GeneratorInitializationContext context)
         {
         }
@@ -35,7 +36,8 @@ namespace SourceGenerators
                 if (!string.IsNullOrWhiteSpace(res))
                 {
                     context.AddSource($"{walker.BaseName}Bindings.g.cs", result.ToString());
-                    File.WriteAllText($"C:\\ObsidianBindingsDebug\\{walker.BaseName}Bindings.g.cs", res);
+                    if (DEBUG)
+                        File.WriteAllText($"C:\\ObsidianBindingsDebug\\{walker.BaseName}Bindings.g.cs", res);
                 }
             }
         }

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -164,7 +164,7 @@ public partial class {_fullName} : global::{_baseTypeNamespace}{_baseType} {_con
 {_nodeNameOverride}
 {(_isValidGenericTypeMethod ? $"    public static bool IsValidGenericType => global::{_currentNameSpace}.{_fullName}.IsValidGenericType;" : "")}
     public override System.Type NodeType => typeof (global::{_currentNameSpace}.{_fullName});
-{(!_isAbstract ? "    public global::{_currentNameSpace}.{_fullName} TypedNodeInstance { get; private set; }" : "")}
+{(!_isAbstract ? $"    public global::{_currentNameSpace}.{_fullName}" + " TypedNodeInstance { get; private set; }" : "")}
 {(!_isAbstract ? "    public override INode NodeInstance => (INode)this.TypedNodeInstance;" : "")}
 {(!_isAbstract ? "    public override void ClearInstance() => this.TypedNodeInstance = null;" : "")}
 {CountOverride}

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -335,7 +335,7 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
             }
             else if (baseTypeName.Contains("AudioNodeBase"))
             {
-                _baseTypeNamespace = "ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio.";
+                _baseTypeNamespace = "FrooxEngine.ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio.";
             }
 
             //if (baseTypeName.Contains("AudioNodeBase"))

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -92,7 +92,7 @@ namespace SourceGenerators
             }
         }
         
-        public const string BindingPrefix = "FrooxEngine.";
+        public const string BindingPrefix = "";
         public const string FluxPrefix = "ProtoFlux.Runtimes.Execution.";
 
         //TODO: add more, this is not all of the valid node types

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -60,7 +60,6 @@ namespace SourceGenerators
             {
                 get
                 {
-                    //if (VariableNames.Count == 0) return "";
                     var str = $@"
     protected override {MethodReturnType} {MethodName}(ref int index)
     {{

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -329,7 +329,7 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
             var baseTypeName = firstBaseType.Type.ToString();
             
             _baseType = baseTypeName;
-            if (baseTypeName.Contains("ProxyVoidNode"))
+            if (node.BaseList.Types.Any(t => t.Type.ToString().Contains("Proxy")))
             {
                 _baseTypeNamespace = "FrooxEngine.FrooxEngine.ProtoFlux.";
             }

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -136,8 +136,8 @@ namespace {BindingPrefix}{_currentNameSpace};
 {_nodeOverloadAttribute}
 {_genericTypesAttribute}
 {_oldTypeNameAttribute}
-{(_backCompat ? $"[OldTypeName(\"{"FrooxEngine." + _currentNameSpace}\")]" : "")}
-[Category(new string[] {{""ProtoFlux/Runtimes/Execution/Nodes/{_category}/{BaseName}""}})]
+{(_backCompat ? $"[OldTypeName(\"{"FrooxEngine." + _currentNameSpace + "." + BaseName}\")]" : "")}
+[Category(new string[] {{""ProtoFlux/Runtimes/Execution/Nodes/{_category}""}})]
 public {(_isAbstract ? "abstract" : "")} class {_fullName} : {_baseType} {_constraints}
 {{
 {(string.IsNullOrEmpty(_debug) ? "" : "//")}{_debug}

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -92,7 +92,7 @@ namespace SourceGenerators
             }
         }
         
-        public const string BindingPrefix = "";
+        public const string BindingPrefix = "Bindings.";
         public const string FluxPrefix = "ProtoFlux.Runtimes.Execution.";
 
         //TODO: add more, this is not all of the valid node types

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -300,7 +300,7 @@ public {(_isAbstract ? "abstract" : "")} class {_fullName} : {_baseType} {_const
                 //    _usingDeclarations.Add("FrooxEngine.ProtoFlux.Runtimes.Execution");
                 //    _usingDeclarations.Add("FrooxEngine.ProtoFlux");
                 //}\
-                if (usingName.StartsWith("ProtoFlux.Runtimes.Execution"))
+                if (usingName == "ProtoFlux.Runtimes.Execution")
                     usingName = "FrooxEngine." + usingName;
                     
                 _usingDeclarations.Add(usingName);

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -172,10 +172,13 @@ public partial class {_fullName} : global::{_baseTypeNamespace}{_baseType} {_con
     public override N Instantiate<N>()
     {
         if (this.TypedNodeInstance != null) throw new System.InvalidOperationException("Node has already been instantiated");
+""" + $"""
         var localVar = new global::{_currentNameSpace}.{_fullName}();
         this.TypedNodeInstance = localVar;
         return localVar as N;
+""" + """
     }
+""" + $"""
     protected override void AssociateInstanceInternal(INode node) => this.TypedNodeInstance = node is global::{_currentNameSpace}.{_fullName} localVar ? localVar : throw new System.ArgumentException("Node instance is not of type " + typeof (global::{_currentNameSpace}.{_fullName})?.ToString());
 """ : "")}
 {GetOverride}

--- a/ProjectObsidian.SourceGenerators/BindingGenerator.cs
+++ b/ProjectObsidian.SourceGenerators/BindingGenerator.cs
@@ -333,7 +333,7 @@ public {(_isAbstract ? "abstract" : "")} partial class {_fullName} : global::{_b
             {
                 _baseTypeNamespace = "FrooxEngine.FrooxEngine.ProtoFlux.";
             }
-            else if (baseTypeName.Contains("AudioNodeBase"))
+            if (baseTypeName.Contains("AudioNodeBase"))
             {
                 _baseTypeNamespace = "FrooxEngine.ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio.";
             }


### PR DESCRIPTION
This removes the hardcoded list of valid node types, it can now work with any class which is detected as a node type (has a node attribute on it)

This means you can make abstract base classes for nodes now (yay for obsidian audio nodes)

The namespace of nodes doesn't matter anymore. The actual generated binding class will always have its namespace prefixed with "Bindings."

However now there needs to be a hardcoded list of additional using statements to add.

(Backwards compatibility has been added due to the bindings namespace change)

(Project Obsidian compiles with these changes and works)